### PR TITLE
feat: expose the horizon accountResponse object for trustline logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-countdown": "^2.3.5",
         "react-dom": "^18.2.0",
         "soroban-client": "1.0.0-beta.2",
+        "stellar-sdk": "^10.4.1",
         "zustand": "^4.3.7"
       },
       "devDependencies": {
@@ -983,6 +984,11 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/eventsource": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA=="
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -992,8 +998,7 @@
     "node_modules/@types/node": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-      "dev": true
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.1",
@@ -1004,6 +1009,14 @@
       "version": "15.7.9",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
       "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g=="
+    },
+    "node_modules/@types/randombytes": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.3.tgz",
+      "integrity": "sha512-+NRgihTfuURllWCiIAhm1wsJqzsocnqXM77V/CalsdJIYSRGEHMnritxh+6EsBklshC+clo1KgnN14qgSGeQdw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/react": {
       "version": "18.0.14",
@@ -1036,6 +1049,11 @@
       "version": "0.16.5",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.5.tgz",
       "integrity": "sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw=="
+    },
+    "node_modules/@types/urijs": {
+      "version": "1.19.22",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.22.tgz",
+      "integrity": "sha512-qnYBwfN7O/+i6E1Kr8JaCKsrCLpRCiQ1XxkSxNIYuJ/5Aagt0+HlMX78DJMUrNzDULMz0eu2gcprlxJaDtACOw=="
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.9.1",
@@ -1633,6 +1651,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1728,6 +1777,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1903,6 +1957,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2356,6 +2415,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.2.tgz",
+      "integrity": "sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3324,11 +3391,24 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/long": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
+      "integrity": "sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3822,6 +3902,14 @@
         }
       ]
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -4225,6 +4313,86 @@
         "sodium-native": "^4.0.1"
       }
     },
+    "node_modules/stellar-sdk": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-10.4.1.tgz",
+      "integrity": "sha512-Wdm2UoLuN9SNrSEHO0R/I+iZuRwUkfny1xg4akhGCpO8LQZw8QzuMTJvbEoMT3sHT4/eWYiteVLp7ND21xZf5A==",
+      "dependencies": {
+        "@types/eventsource": "^1.1.2",
+        "@types/node": ">= 8",
+        "@types/randombytes": "^2.0.0",
+        "@types/urijs": "^1.19.6",
+        "axios": "0.25.0",
+        "bignumber.js": "^4.0.0",
+        "detect-node": "^2.0.4",
+        "es6-promise": "^4.2.4",
+        "eventsource": "^1.1.1",
+        "lodash": "^4.17.21",
+        "randombytes": "^2.1.0",
+        "stellar-base": "^8.2.2",
+        "toml": "^2.3.0",
+        "tslib": "^1.10.0",
+        "urijs": "^1.19.1",
+        "utility-types": "^3.7.0"
+      }
+    },
+    "node_modules/stellar-sdk/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
+      }
+    },
+    "node_modules/stellar-sdk/node_modules/bignumber.js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stellar-sdk/node_modules/js-xdr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-1.3.0.tgz",
+      "integrity": "sha512-fjLTm2uBtFvWsE3l2J14VjTuuB8vJfeTtYuNS7LiLHDWIX2kt0l1pqq9334F8kODUkKPMuULjEcbGbkFFwhx5g==",
+      "dependencies": {
+        "lodash": "^4.17.5",
+        "long": "^2.2.3"
+      }
+    },
+    "node_modules/stellar-sdk/node_modules/sodium-native": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.4.1.tgz",
+      "integrity": "sha512-PaNN/roiFWzVVTL6OqjzYct38NSXewdl2wz8SRB51Br/MLIJPrbM3XexhVWkq7D3UWMysfrhKVf1v1phZq6MeQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
+    "node_modules/stellar-sdk/node_modules/stellar-base": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-8.2.2.tgz",
+      "integrity": "sha512-YVCIuJXU1bPn+vU0ded+g0D99DcpYXH9CEXfpYEDc4Gf04h65YjOVhGojQBm1hqVHq3rKT7m1tgfNACkU84FTA==",
+      "dependencies": {
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^4.0.0",
+        "crc": "^3.5.0",
+        "js-xdr": "^1.1.3",
+        "lodash": "^4.17.21",
+        "sha.js": "^2.3.6",
+        "tweetnacl": "^1.0.3"
+      },
+      "optionalDependencies": {
+        "sodium-native": "^3.3.0"
+      }
+    },
+    "node_modules/stellar-sdk/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
@@ -4410,6 +4578,11 @@
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
+    "node_modules/toml": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
+      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ=="
+    },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -4581,6 +4754,14 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -11,19 +11,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@blend-capital/blend-sdk": "^0.0.4",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.6",
     "@stellar/freighter-api": "^1.4.0",
     "bignumber.js": "^9.0.2",
-    "@blend-capital/blend-sdk": "^0.0.4",
     "copy-to-clipboard": "^3.3.3",
     "next": "^12.3.4",
     "react": "^18.2.0",
     "react-countdown": "^2.3.5",
     "react-dom": "^18.2.0",
     "soroban-client": "1.0.0-beta.2",
+    "stellar-sdk": "^10.4.1",
     "zustand": "^4.3.7"
   },
   "devDependencies": {

--- a/src/contexts/wallet.tsx
+++ b/src/contexts/wallet.tsx
@@ -50,6 +50,7 @@ const WalletContext = React.createContext<IWalletContext | undefined>(undefined)
 export const WalletProvider = ({ children = null as any }) => {
   const network = useStore((state) => state.network);
   const backstopClient = useStore((state) => state.backstopContract);
+  const loadAccount = useStore((state) => state.loadAccount);
   const removeUserState = useStore((state) => state.removeUserData);
 
   const [connected, setConnected] = useState<boolean>(false);
@@ -77,6 +78,7 @@ export const WalletProvider = ({ children = null as any }) => {
       publicKey = await getPublicKey();
       setWalletAddress(publicKey);
       setConnected(true);
+      await loadAccount(publicKey);
     } catch (e: any) {
       error = e?.message ?? 'Failed to connect wallet.';
     }
@@ -122,6 +124,14 @@ export const WalletProvider = ({ children = null as any }) => {
         console.log('Failed submitted transaction: ', result.hash);
         setTxStatus(TxStatus.FAIL);
       }
+
+      // reload Horizon account after submission
+      try {
+        await loadAccount(walletAddress);
+      } catch {
+        console.error('Failed loading account: ', walletAddress);
+      }
+
       return result.unwrap();
     } catch (e) {
       console.error('Failed submitting transaction: ', e);

--- a/src/store/horizonSlice.ts
+++ b/src/store/horizonSlice.ts
@@ -1,0 +1,34 @@
+import { AccountResponse, Server as Horizon } from 'stellar-sdk';
+import { StateCreator } from 'zustand';
+import { DataStore } from './store';
+
+export interface HorizonSlice {
+  horizon: {
+    url: string;
+    opts?: Horizon.Options;
+  };
+  horizonServer: () => Horizon;
+  setHorizon: (url: string, opts?: Horizon.Options) => void;
+  account: AccountResponse | undefined;
+  loadAccount: (id: string) => Promise<void>;
+}
+
+export const createHorizonSlice: StateCreator<DataStore, [], [], HorizonSlice> = (set, get) => ({
+  horizon: {
+    url: 'https://horizon-futurenet.stellar.org',
+    opts: undefined,
+  },
+  horizonServer: () => {
+    let horizon = get().horizon;
+    return new Horizon(horizon.url, horizon.opts);
+  },
+  setHorizon: (newUrl, newOpts) => {
+    set({ horizon: { url: newUrl, opts: newOpts } });
+  },
+  account: undefined,
+  loadAccount: async (id) => {
+    let horizon = get().horizonServer();
+    let account = await horizon.loadAccount(id);
+    set({ account });
+  },
+});

--- a/src/store/rpcSlice.ts
+++ b/src/store/rpcSlice.ts
@@ -3,13 +3,13 @@ import { Server } from 'soroban-client';
 import { StateCreator } from 'zustand';
 import { DataStore } from './store';
 
-export interface NetworkSlice {
+export interface RPCSlice {
   network: Network;
   rpcServer: () => Server;
   setNetwork: (rpcUrl: string, newPassphrase: string, opts?: Server.Options) => void;
 }
 
-export const createNetworkSlice: StateCreator<DataStore, [], [], NetworkSlice> = (set, get) => ({
+export const createRPCSlice: StateCreator<DataStore, [], [], RPCSlice> = (set, get) => ({
   network: {
     rpc: 'https://rpc-futurenet.stellar.org',
     passphrase: 'Test SDF Future Network ; October 2022',

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3,12 +3,13 @@ import { devtools } from 'zustand/middleware';
 import { BackstopSlice, BackstopUserData, createBackstopSlice } from './backstopSlice';
 import {
   BackstopUserEstimates,
+  createEstimationSlice,
   EstimationSlice,
   PoolUserEstimates,
-  createEstimationSlice,
 } from './estimationSlice';
-import { NetworkSlice, createNetworkSlice } from './networkSlice';
-import { PoolSlice, PoolUserData, createPoolSlice } from './poolSlice';
+import { createHorizonSlice, HorizonSlice } from './horizonSlice';
+import { createPoolSlice, PoolSlice, PoolUserData } from './poolSlice';
+import { createRPCSlice, RPCSlice } from './rpcSlice';
 
 (BigInt.prototype as any).toJSON = function () {
   return this.toString();
@@ -18,7 +19,8 @@ interface BaseDataStoreSlice {
   removeUserData: () => void;
 }
 
-export type DataStore = NetworkSlice &
+export type DataStore = RPCSlice &
+  HorizonSlice &
   BackstopSlice &
   PoolSlice &
   EstimationSlice &
@@ -26,7 +28,8 @@ export type DataStore = NetworkSlice &
 
 export const useStore = create<DataStore>()(
   devtools((...args) => ({
-    ...createNetworkSlice(...args),
+    ...createRPCSlice(...args),
+    ...createHorizonSlice(...args),
     ...createBackstopSlice(...args),
     ...createPoolSlice(...args),
     ...createEstimationSlice(...args),
@@ -36,6 +39,7 @@ export const useStore = create<DataStore>()(
         backstopUserData: new Map<string, BackstopUserData>(),
         pool_user_est: new Map<string, PoolUserEstimates>(),
         backstop_user_est: new Map<string, BackstopUserEstimates>(),
+        account: undefined,
       }));
     },
   }))


### PR DESCRIPTION
Expose the Horizon AccountResponse so the UI can begin to add logic based on current trustlines on a wallet