### PR TITLE
fix: patch math for emissions in backstop APY component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blend-ui",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blend-ui",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@blend-capital/blend-sdk": "1.2.0",
         "@creit.tech/stellar-wallets-kit": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blend-ui",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/backstop/BackstopAPY.tsx
+++ b/src/components/backstop/BackstopAPY.tsx
@@ -17,11 +17,17 @@ export const BackstopAPY: React.FC<PoolComponentProps> = ({ poolId, sx, ...props
           poolData.estimates.totalBorrow) /
         backstopPoolData.estimates.totalSpotValue
       : 0;
+  const sharesToTokens = backstopPoolData
+    ? Number(backstopPoolData.poolBalance.tokens) / Number(backstopPoolData.poolBalance.shares)
+    : 1;
   const backstopEmissionsPerDayPerLPToken =
     backstopPoolData && backstopPoolData.emissions
       ? getEmissionsPerYearPerUnit(
           backstopPoolData.emissions.config.eps,
-          Number(backstopPoolData.poolBalance.shares - backstopPoolData.poolBalance.q4w) / 1e7,
+          ((Number(backstopPoolData.poolBalance.shares) -
+            Number(backstopPoolData.poolBalance.q4w)) /
+            1e7) *
+            sharesToTokens,
           7
         )
       : 0;


### PR DESCRIPTION
Fix a bug in the emissions calculation where the BLND/year was displayed as per LP token, but was being calculated per backstop share.